### PR TITLE
fix: extend mobile menu visibility to 1280px

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
       .mobile-menu {
         display: none;
       }
-      @media (max-width: 768px) {
+      @media (max-width: 1280px) {
         .desktop-menu {
           display: none;
         }
@@ -137,7 +137,7 @@
             </div>
             <span class="text-xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">Flashy.js</span>
           </div>
-          <div class="desktop-menu hidden md:flex items-center space-x-8">
+          <div class="desktop-menu hidden xl:flex items-center space-x-8">
             <a href="#inicio" class="text-gray-600 hover:text-primary transition-colors">Inicio</a>
             <a href="#instalacion" class="text-gray-600 hover:text-primary transition-colors">Instalación</a>
             <a href="#ejemplos" class="text-gray-600 hover:text-primary transition-colors">Ejemplos</a>
@@ -154,8 +154,8 @@
                       title="GitHub Star Button"></iframe>
             </div>
           </div>
-          <div class="mobile-menu md:hidden">
-            <button id="mobile-menu-toggle" class="text-gray-600 hover:text-primary">
+          <div class="mobile-menu xl:hidden">
+            <button id="mobile-menu-toggle" class="text-gray-600 hover:text-primary" ariba-label="Abrir menú">
               <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" />
               </svg>


### PR DESCRIPTION
## Descripción  
El menú hamburguesa se ocultaba en pantallas de tablet (768px +), donde los enlaces de navegación no se veían completos. Este cambio ajusta el breakpoint para que el menú móvil sea visible hasta 1280px, mejorando la usabilidad en dispositivos medianos.
#### Antes
![flashyjs pablomsj com_](https://github.com/user-attachments/assets/baea4286-2f03-432f-8d5c-4cd6ccc9cfdb)

#### Después
![127 0 0 1_5500_index html](https://github.com/user-attachments/assets/fbe07e55-4afd-4886-9e3b-db770abdffbd)

## Tipo de Cambio  
- [X] Bug fix (arreglé algo roto)  

## ¿Cómo lo probaste?  
1. **Dispositivos simulados**: Usé las herramientas de desarrollador de Chrome para probar en:  
   - iPhone SE (375px): Menú hamburguesa visible ✅  
   - iPad Air (820px): Menú hamburguesa visible ✅  
   - Laptop (1279px): Menú hamburguesa visible ✅  
   - Laptop (1280px+): Menú hamburguesa oculto, muestra navegación desktop ✅  

## Checklist del Perfeccionista:  
- [X] Mi código no da pena  
- [X] Me revisé a mí mismo (autocrítica constructiva)  
- [X] No rompí nada (que sepa)  
